### PR TITLE
Error message: Don't know how to deal with an undetermined Perl reference

### DIFF
--- a/pl_duk.c
+++ b/pl_duk.c
@@ -266,7 +266,7 @@ static int pl_perl_to_duk_impl(pTHX_ SV* value, duk_context* ctx, HV* seen, int 
                 croak("Could not associate C dispatcher and Perl callback\n");
             }
         } else {
-            croak("Don't know how to deal with an undetermined Perl reference\n");
+            croak("Don't know how to deal with an undetermined Perl reference (type: %d)\n", type);
             ret = 0;
         }
     } else {


### PR DESCRIPTION
The tests for https://github.com/gflohr/qgoda widely fail (for example http://www.cpantesters.org/cpan/report/e59565f8-e042-11e8-bb82-9f1c04f5d97e) with the error message: "Don't know how to deal with an undetermined Perl reference".  This PR adds the unrecognized type to the error messge so that the problem can be diagnosed better.