### PR TITLE
Fix compilation error in 0.76 release

### DIFF
--- a/pl_console.c
+++ b/pl_console.c
@@ -68,7 +68,7 @@ static int save_console_messages(duk_uint_t flags, void* data,
     SV* message = newSVpvs("");
     va_list args_copy;
     va_copy(args_copy, ap);
-    sv_vcatpvf(aTHX_ message, fmt, &args_copy);
+    sv_vcatpvf(message, fmt, &args_copy);
     save_msg(aTHX_ duk, target, message);
     return SvCUR(message);
 }


### PR DESCRIPTION
After 0.76 release I can't compile this module.

```
$ LANG=C make
cp lib/JavaScript/Duktape/XS.pm blib/lib/JavaScript/Duktape/XS.pm
Running Mkbootstrap for JavaScript::Duktape::XS ()
chmod 644 "XS.bs"
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   c_eventloop.c
"/usr/bin/perl" "/usr/share/perl/5.24/ExtUtils/xsubpp"  -typemap "/usr/share/perl/5.24/ExtUtils/typemap" -typemap "typemap"  duk.xs > duk.xsc && mv duk.xsc duk.c
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   duk.c
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   duk_console.c
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   duk_module_node.c
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   duktape.c
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   pl_console.c
In file included from /usr/lib/x86_64-linux-gnu/perl/5.24/CORE/perl.h:5615:0,
                 from pl_duk.h:7,
                 from pl_sandbox.h:4,
                 from duk_config.h:2816,
                 from duktape.h:174,
                 from duk_console.h:5,
                 from pl_console.c:2:
pl_console.c: In function 'save_console_messages':
/usr/lib/x86_64-linux-gnu/perl/5.24/CORE/perl.h:166:16: warning: passing argument 2 of 'Perl_sv_vcatpvf' from incompatible pointer type [-Wincompatible-pointer-types]
 #  define aTHX my_perl
                ^
/usr/lib/x86_64-linux-gnu/perl/5.24/CORE/embed.h:692:49: note: in definition of macro 'sv_vcatpvf'
 #define sv_vcatpvf(a,b,c) Perl_sv_vcatpvf(aTHX_ a,b,c)
                                                 ^
/usr/lib/x86_64-linux-gnu/perl/5.24/CORE/perl.h:179:18: note: in expansion of macro 'aTHX'
 #  define aTHX_  aTHX,
                  ^~~~
pl_console.c:71:16: note: in expansion of macro 'aTHX_'
     sv_vcatpvf(aTHX_ message, fmt, &args_copy);
                ^~~~~
In file included from /usr/lib/x86_64-linux-gnu/perl/5.24/CORE/perl.h:5580:0,
                 from pl_duk.h:7,
                 from pl_sandbox.h:4,
                 from duk_config.h:2816,
                 from duktape.h:174,
                 from duk_console.h:5,
                 from pl_console.c:2:
/usr/lib/x86_64-linux-gnu/perl/5.24/CORE/proto.h:3267:20: note: expected 'SV * const {aka struct sv * const}' but argument is of type 'PerlInterpreter * {aka struct interpreter *}'
 PERL_CALLCONV void Perl_sv_vcatpvf(pTHX_ SV *const sv, const char *const pat, va_list *const args);
                    ^~~~~~~~~~~~~~~
In file included from /usr/lib/x86_64-linux-gnu/perl/5.24/CORE/perl.h:5615:0,
                 from pl_duk.h:7,
                 from pl_sandbox.h:4,
                 from duk_config.h:2816,
                 from duktape.h:174,
                 from duk_console.h:5,
                 from pl_console.c:2:
pl_console.c:71:22: warning: passing argument 3 of 'Perl_sv_vcatpvf' from incompatible pointer type [-Wincompatible-pointer-types]
     sv_vcatpvf(aTHX_ message, fmt, &args_copy);
                      ^
/usr/lib/x86_64-linux-gnu/perl/5.24/CORE/embed.h:692:49: note: in definition of macro 'sv_vcatpvf'
 #define sv_vcatpvf(a,b,c) Perl_sv_vcatpvf(aTHX_ a,b,c)
                                                 ^
In file included from /usr/lib/x86_64-linux-gnu/perl/5.24/CORE/perl.h:5580:0,
                 from pl_duk.h:7,
                 from pl_sandbox.h:4,
                 from duk_config.h:2816,
                 from duktape.h:174,
                 from duk_console.h:5,
                 from pl_console.c:2:
/usr/lib/x86_64-linux-gnu/perl/5.24/CORE/proto.h:3267:20: note: expected 'const char * const' but argument is of type 'SV * {aka struct sv *}'
 PERL_CALLCONV void Perl_sv_vcatpvf(pTHX_ SV *const sv, const char *const pat, va_list *const args);
                    ^~~~~~~~~~~~~~~
In file included from /usr/lib/x86_64-linux-gnu/perl/5.24/CORE/perl.h:5615:0,
                 from pl_duk.h:7,
                 from pl_sandbox.h:4,
                 from duk_config.h:2816,
                 from duktape.h:174,
                 from duk_console.h:5,
                 from pl_console.c:2:
pl_console.c:71:31: warning: passing argument 4 of 'Perl_sv_vcatpvf' from incompatible pointer type [-Wincompatible-pointer-types]
     sv_vcatpvf(aTHX_ message, fmt, &args_copy);
                               ^
/usr/lib/x86_64-linux-gnu/perl/5.24/CORE/embed.h:692:51: note: in definition of macro 'sv_vcatpvf'
 #define sv_vcatpvf(a,b,c) Perl_sv_vcatpvf(aTHX_ a,b,c)
                                                   ^
In file included from /usr/lib/x86_64-linux-gnu/perl/5.24/CORE/perl.h:5580:0,
                 from pl_duk.h:7,
                 from pl_sandbox.h:4,
                 from duk_config.h:2816,
                 from duktape.h:174,
                 from duk_console.h:5,
                 from pl_console.c:2:
/usr/lib/x86_64-linux-gnu/perl/5.24/CORE/proto.h:3267:20: note: expected '__va_list_tag (* const)[1]' but argument is of type 'const char *'
 PERL_CALLCONV void Perl_sv_vcatpvf(pTHX_ SV *const sv, const char *const pat, va_list *const args);
                    ^~~~~~~~~~~~~~~
In file included from /usr/lib/x86_64-linux-gnu/perl/5.24/CORE/perl.h:5615:0,
                 from pl_duk.h:7,
                 from pl_sandbox.h:4,
                 from duk_config.h:2816,
                 from duktape.h:174,
                 from duk_console.h:5,
                 from pl_console.c:2:
/usr/lib/x86_64-linux-gnu/perl/5.24/CORE/embed.h:692:27: error: too many arguments to function 'Perl_sv_vcatpvf'
 #define sv_vcatpvf(a,b,c) Perl_sv_vcatpvf(aTHX_ a,b,c)
                           ^
pl_console.c:71:5: note: in expansion of macro 'sv_vcatpvf'
     sv_vcatpvf(aTHX_ message, fmt, &args_copy);
     ^~~~~~~~~~
In file included from /usr/lib/x86_64-linux-gnu/perl/5.24/CORE/perl.h:5580:0,
                 from pl_duk.h:7,
                 from pl_sandbox.h:4,
                 from duk_config.h:2816,
                 from duktape.h:174,
                 from duk_console.h:5,
                 from pl_console.c:2:
/usr/lib/x86_64-linux-gnu/perl/5.24/CORE/proto.h:3267:20: note: declared here
 PERL_CALLCONV void Perl_sv_vcatpvf(pTHX_ SV *const sv, const char *const pat, va_list *const args);
                    ^~~~~~~~~~~~~~~
Makefile:379: recipe for target 'pl_console.o' failed
make: *** [pl_console.o] Error 1
```

And after this fix it compiles successfully

```
$ make
Skip blib/lib/JavaScript/Duktape/XS.pm (unchanged)
Running Mkbootstrap for JavaScript::Duktape::XS ()
chmod 644 "XS.bs"
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   c_eventloop.c
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   duk.c
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   duk_console.c
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   duk_module_node.c
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   duktape.c
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   pl_console.c
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   pl_duk.c
pl_duk.c: In function ‘pl_duk_to_perl’:
pl_duk.c:289:5: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
     SV* ret = pl_duk_to_perl_impl(aTHX_ ctx, pos, seen);
     ^~
pl_duk.c: In function ‘pl_perl_to_duk’:
pl_duk.c:299:5: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
     int ret = pl_perl_to_duk_impl(aTHX_ value, ctx, seen, 0);
     ^~~
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   pl_eventloop.c
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   pl_inlined.c
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   pl_module.c
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   pl_native.c
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   pl_sandbox.c
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   pl_stats.c
x86_64-linux-gnu-gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wdeclaration-after-statement -Wcomment -O2 -g   -DVERSION=\"0.000076\" -DXS_VERSION=\"0.000076\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.24/CORE"   pl_util.c
rm -f blib/arch/auto/JavaScript/Duktape/XS/XS.so
x86_64-linux-gnu-gcc  -shared -L/usr/local/lib -fstack-protector-strong c_eventloop.o duk.o duk_console.o duk_module_node.o duktape.o pl_console.o pl_duk.o pl_eventloop.o pl_inlined.o pl_module.o pl_native.o pl_sandbox.o pl_stats.o pl_util.o  -o blib/arch/auto/JavaScript/Duktape/XS/XS.so       \
        \
  
chmod 755 blib/arch/auto/JavaScript/Duktape/XS/XS.so
"/usr/bin/perl" -MExtUtils::Command::MM -e 'cp_nonempty' -- XS.bs blib/arch/auto/JavaScript/Duktape/XS/XS.bs 644
Manifying 1 pod document
```

As I understood https://perldoc.perl.org/perlguts.html you don't need to pass `aTHX_` in functions without `Perl_` prefix. I also found same issue report on cpan: https://rt.cpan.org/Ticket/Display.html?id=129070