### PR TITLE
Compatibility with perl 5.14

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,7 +6,7 @@ WriteMakefile(
     VERSION_FROM   => 'lib/JavaScript/Duktape/XS.pm',
     ABSTRACT_FROM  => 'lib/JavaScript/Duktape/XS.pm',
     LICENSE        => 'mit',
-    MIN_PERL_VERSION => 5.018000,
+    MIN_PERL_VERSION => 5.014000,
     PREREQ_PM      => {
         'JSON::PP'     => 0,
         'XSLoader'     => 0,

--- a/pl_console.c
+++ b/pl_console.c
@@ -39,7 +39,7 @@ static void save_msg(pTHX_ Duk* duk, const char* target, SV* message)
             return;
         }
         data = (AV*) ref;
-        top = av_top_index(data);
+        top = av_len(data);
     } else {
         SV* ref = 0;
         data = newAV();

--- a/pl_duk.c
+++ b/pl_duk.c
@@ -193,7 +193,7 @@ static int pl_perl_to_duk_impl(pTHX_ SV* value, duk_context* ctx, HV* seen, int 
                     SvREFCNT_inc(uptr);
                 }
 
-                array_top = av_top_index(values);
+                array_top = av_len(values);
                 for (j = 0; j <= array_top; ++j) { /* yes, [0, array_top] */
                     SV** elem = av_fetch(values, j, 0);
                     if (!elem || !*elem) {


### PR DESCRIPTION
We need to use this module with perl 5.14. Unfortunetely it has test failures on this version of perl (with patch from https://github.com/gonzus/JavaScript-Duktape-XS/pull/18 included):

```
$ make test
Running Mkbootstrap for JavaScript::Duktape::XS ()
chmod 644 XS.bs
PERL_DL_NONLAZY=1 /usr/bin/perl "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/00_basic.t ......... 1/? 
#   Failed test 'use JavaScript::Duktape::XS;'
#   at t/00_basic.t line 138.
#     Tried to use 'JavaScript::Duktape::XS'.
#     Error:  Can't load '/tmp/JavaScript-Duktape-XS-0.000076/blib/arch/auto/JavaScript/Duktape/XS/XS.so' for module JavaScript::Duktape::XS: /tmp/JavaScript-Duktape-XS-0.000076/blib/arch/auto/JavaScript/Duktape/XS/XS.so: undefined symbol: av_top_index at /usr/lib/perl/5.14/DynaLoader.pm line 184.
#  at t/00_basic.t line 138.
# Compilation failed in require at t/00_basic.t line 138.
# BEGIN failed--compilation aborted at t/00_basic.t line 138.
Can't locate object method "new" via package "JavaScript::Duktape::XS" at t/00_basic.t line 11.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 255 just after 1.
t/00_basic.t ......... Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 1/1 subtests
...
```

This is because `av_top_index` is not defined in 5.14. But in https://perldoc.perl.org/perlapi.html we can see that `av_top_index()` is the same as `av_len()`. So after this changes all tests passed on 5.14.