### PR TITLE
Prefer string value for dualvars (closes #20)

### DIFF
--- a/pl_duk.c
+++ b/pl_duk.c
@@ -153,6 +153,10 @@ static int pl_perl_to_duk_impl(pTHX_ SV* value, duk_context* ctx, HV* seen, int 
     } else if (sv_isa(value, PL_JSON_BOOLEAN_CLASS)) {
         int val = SvTRUE(value);
         duk_push_boolean(ctx, val);
+    } else if (SvPOK(value)) {
+        STRLEN vlen = 0;
+        const char* vstr = SvPV_const(value, vlen);
+        duk_push_lstring(ctx, vstr, vlen);
     } else if (SvIOK(value)) {
         long val = SvIV(value);
         if (ref && (val == 0 || val == 1)) {
@@ -163,10 +167,6 @@ static int pl_perl_to_duk_impl(pTHX_ SV* value, duk_context* ctx, HV* seen, int 
     } else if (SvNOK(value)) {
         double val = SvNV(value);
         duk_push_number(ctx, (duk_double_t) val);
-    } else if (SvPOK(value)) {
-        STRLEN vlen = 0;
-        const char* vstr = SvPV_const(value, vlen);
-        duk_push_lstring(ctx, vstr, vlen);
     } else if (SvROK(value)) {
         SV* ref = SvRV(value);
         int type = SvTYPE(ref);

--- a/t/23_dualvar.t
+++ b/t/23_dualvar.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+
+use Data::Dumper;
+use Scalar::Util 'dualvar';
+use JSON::PP;
+use Test::More;
+
+my $CLASS = 'JavaScript::Duktape::XS';
+
+sub test_dualvars {
+    my $vm = $CLASS->new();
+    ok($vm, "created $CLASS object");
+    
+    my $dualvar_implicit = "0345";
+    $dualvar_implicit == 234 and die;
+    
+    my $dualvar_expicit = dualvar(854, 'hi there');
+
+    my %data = (
+        scalar => $dualvar_implicit,
+        array => [ 'xxx', $dualvar_expicit, $dualvar_implicit ],
+        hash => { foo => $dualvar_implicit, bar => $dualvar_expicit, baz => 99 },
+    );
+    
+    my $j = JSON::PP->new->canonical(1)->allow_nonref(1);
+
+    foreach my $type (sort keys %data) {
+        my $expected = $j->encode( $data{$type} );
+        $vm->set($type, $data{$type});
+        my $got = $j->encode( $vm->get($type) );
+        is_deeply($got, $expected, "conversion of dualvars for $type was correct");
+    }
+}
+
+sub main {
+    use_ok($CLASS);
+
+    test_dualvars();
+    done_testing;
+    return 0;
+}
+
+exit main();


### PR DESCRIPTION
`JSON::PP`, `JSON::XS` uses string value for dualvars, so this module needs to do the same. I just changed the order of check for data types for this to work. JSON::XS makes the same: https://metacpan.org/source/MLEHMANN/JSON-XS-4.02/XS.xs#L898

Can you also make new release to CPAN after this will be merged? There were many changes in this repo since last release.