### PR TITLE
Fix character-encoding oddities, add documentation.

### DIFF
--- a/lib/JavaScript/Duktape/XS.pm
+++ b/lib/JavaScript/Duktape/XS.pm
@@ -121,6 +121,22 @@ The Perl value is converted into an equivalent JavaScript value, so you can
 freely pass nested structures (hashes of arrays of hashes) and they will be
 handled correctly.
 
+Plain scalars are converted thus:
+
+=over
+
+=item * Instances of L<JSON::PP::Boolean> become JavaScript booleans.
+
+=item * Strings are interpreted as character strings. For example,
+Perl C<"\xff"> will become C<"\u00ff"> in JavaScript.
+
+(If you see mangled Unicode in JavaScript, you may have neglected a
+character-decode step. See L<perlunitut> for more details.)
+
+=item * Integers & floats become JavaScript numbers.
+
+=back
+
 You can also pass a Perl coderef as a value, in which case the named JavaScript
 variable / object slot becomes a function which, when executed, will end up
 calling the Perl coderef.  Any values passed from JavaScript into the Perl
@@ -135,6 +151,10 @@ Get the value stored in a JavaScript variable or object slot.
 The JavaScript value is converted into an equivalent Perl value, so you can
 freely pass nested structures (hashes of arrays of hashes) and they will be
 handled correctly.
+
+JavaScript strings become Perl character strings. If you find these strings
+printing strangely, you may need to encode them before printing; see
+L<perlunitut> for more details.
 
 =head2 remove
 

--- a/t/25_unicode.t
+++ b/t/25_unicode.t
@@ -1,0 +1,58 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+my $CLASS = 'JavaScript::Duktape::XS';
+
+sub main {
+    use_ok($CLASS);
+
+    my $ff = "\xff";
+    my $e_acute_utf8 = "\xc3\xa9";
+
+    for my $upgrade_yn ( 0, 1 ) {
+        my $_ff = $ff;
+
+        my $xform_fn = $upgrade_yn ? 'upgrade' : 'downgrade';
+        utf8->can($xform_fn)->($_ff);
+
+        my $_e_acute_utf8 = $e_acute_utf8;
+        utf8->can($xform_fn)->($_e_acute_utf8);
+
+        my $vm = $CLASS->new();
+
+        $vm->set( mystr => $_e_acute_utf8 );
+        $vm->set( myhash => { $_ff => $_ff } );
+
+        my $got = $vm->eval( q<[mystr, mystr.charCodeAt(0), myhash, myhash["\u00ff"].charCodeAt(0)]> );
+
+        is_deeply(
+            $got,
+            [ $e_acute_utf8, 0xc3, { $ff => $ff }, 0xff ],
+            "round-trip as expected (utf8::$xform_fn)",
+        ) or diag explain $got;
+    }
+
+    {
+        my $a_line = "\x{100}";
+
+        my $vm = $CLASS->new();
+
+        $vm->set( mystr => $a_line );
+        $vm->set( myhash => { $a_line => $a_line } );
+
+        my $got = $vm->eval( q<[mystr, mystr.charCodeAt(0), myhash, myhash[mystr].charCodeAt(0)]> );
+
+        is_deeply(
+            $got,
+            [ $a_line, 0x100, { $a_line => $a_line }, 0x100 ],
+            "wide character round-trips as expected",
+        ) or diag explain $got;
+    }
+
+    done_testing;
+    return 0;
+}
+
+exit main();


### PR DESCRIPTION
Issue #23: This makes this module’s behaviour more uniform so callers
don’t need to worry about Perl internals.