### PR TITLE
Handle undefined in a returned array.

### DIFF
--- a/t/26_eval_returns_hole_in_array.t
+++ b/t/26_eval_returns_hole_in_array.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use blib;
+
+use JavaScript::Duktape::XS;
+
+my $js = JavaScript::Duktape::XS->new();
+
+my $got = $js->eval('var foo = []; foo[1] = 123; foo');
+
+is_deeply(
+    $got,
+    [undef, 123],
+    '[(empty), 123]',
+) or diag explain $got;
+
+$got = $js->eval('var foo = []; foo[1] = undefined; foo');
+
+is_deeply(
+    $got,
+    [undef, undef],
+    '[(empty), undefined]',
+) or diag explain $got;
+
+$got = $js->eval('[undefined, undefined]');
+
+is_deeply(
+    $got,
+    [undef, undef],
+    '[undefined, undefined]',
+) or diag explain $got;
+
+done_testing;


### PR DESCRIPTION
Issue #30: JS “undefined” causes Duktape’s duk_get_prop_index()
to return false, even though the value *does* exist. (This is an
apparent bug either in Duktape or its documentation, which suggests
that any existent property should cause a truthy return from that
function.) In that case pl_duk_to_perl_impl() was neglecting to
duk_pop(ctx), which caused the next read on the array to be an attempt
to read index 1 from undefined, which triggered an abort().

This fixes that by ensuring that we always duk_pop(ctx) in the relevant
piece of code.