### PR TITLE
Catchable Perl exceptions

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,6 +21,7 @@ WriteMakefile(
         'Test::Output'       => 0,
         'Text::Trim'         => 0,
         'Time::HiRes'        => 0,
+        'Test::MemoryGrowth' => 0,
     },
     AUTHOR         => [
         'Gonzalo Diethelm (gonzus@cpan.org)',

--- a/duk.xs
+++ b/duk.xs
@@ -144,6 +144,10 @@ static Duk* create_duktape_object(pTHX_ HV* opt)
                 duk->max_timeout_us = param > MAX_TIMEOUT_MINIMUM ? param : MAX_TIMEOUT_MINIMUM;
                 continue;
             }
+            if (memcmp(kstr, DUK_OPT_NAME_CATCH_PERL_EXCEPTIONS, klen) == 0) {
+                duk->flags |= SvTRUE(value) ? DUK_OPT_FLAG_CATCH_PERL_EXCEPTIONS : 0;
+                continue;
+            }
             croak("Unknown option %*.*s\n", (int) klen, (int) klen, kstr);
         }
     }

--- a/lib/JavaScript/Duktape/XS.pm
+++ b/lib/JavaScript/Duktape/XS.pm
@@ -32,10 +32,11 @@ Version 0.000080
     my $vm = JavaScript::Duktape::XS->new();
 
     my $options = {
-        gather_stats     => 1,
-        save_messages    => 1,
-        max_memory_bytes => 256*1024,
-        max_timeout_us   => 2*1_000_000,
+        gather_stats          => 1,
+        save_messages         => 1,
+        max_memory_bytes      => 256*1024,
+        max_timeout_us        => 2*1_000_000,
+        catch_perl_exceptions => 1,
     };
     my $vm = JavaScript::Duktape::XS->new($options);
 
@@ -112,6 +113,15 @@ not used, there is no limit in place.
 
 Limit the execution runtime of any single JavaScript call to this many
 microseconds.  If this option is not used, there is no limit in place.
+
+=head3 catch_perl_exceptions
+
+Convert Perl exceptions that are thrown with C<die()> into a JavaScript
+C<Error> object. These exception can then be caught in a C<catch> block in
+the JavaScript code that had invoked Perl.  If this option is not used, Perl
+exceptions are fatal from JavaScript's perspective and cannot be caught.
+
+This option was added in version 0.000080.
 
 =head2 set
 

--- a/pl_duk.h
+++ b/pl_duk.h
@@ -7,15 +7,17 @@
 #include "perl.h"
 #include "ppport.h"
 
-#define DUK_OPT_NAME_GATHER_STATS      "gather_stats"
-#define DUK_OPT_NAME_SAVE_MESSAGES     "save_messages"
-#define DUK_OPT_NAME_MAX_MEMORY_BYTES  "max_memory_bytes"
-#define DUK_OPT_NAME_MAX_TIMEOUT_US    "max_timeout_us"
+#define DUK_OPT_NAME_GATHER_STATS           "gather_stats"
+#define DUK_OPT_NAME_SAVE_MESSAGES          "save_messages"
+#define DUK_OPT_NAME_MAX_MEMORY_BYTES       "max_memory_bytes"
+#define DUK_OPT_NAME_MAX_TIMEOUT_US         "max_timeout_us"
+#define DUK_OPT_NAME_CATCH_PERL_EXCEPTIONS  "catch_resolver_errors"
 
-#define DUK_OPT_FLAG_GATHER_STATS      0x01
-#define DUK_OPT_FLAG_SAVE_MESSAGES     0x02
-#define DUK_OPT_FLAG_MAX_MEMORY_BYTES  0x04
-#define DUK_OPT_FLAG_MAX_TIMEOUT_US    0x08
+#define DUK_OPT_FLAG_GATHER_STATS           0x01
+#define DUK_OPT_FLAG_SAVE_MESSAGES          0x02
+#define DUK_OPT_FLAG_MAX_MEMORY_BYTES       0x04
+#define DUK_OPT_FLAG_MAX_TIMEOUT_US         0x08
+#define DUK_OPT_FLAG_CATCH_PERL_EXCEPTIONS  0x10
 
 #define PL_NAME_ROOT              "_perl_"
 #define PL_NAME_GENERIC_CALLBACK  "generic_callback"

--- a/t/51_memory_leaks.t
+++ b/t/51_memory_leaks.t
@@ -2,7 +2,11 @@ use strict;
 use warnings;
 
 use Test::More;
-use Test::MemoryGrowth;
+
+eval { require Test::MemoryGrowth };
+if ($@) {
+	plan skip_all => 'Test::MemoryGrowth not installed or not working';
+}
 
 use JavaScript::Duktape::XS;
 

--- a/t/60_resolve.t
+++ b/t/60_resolve.t
@@ -1,0 +1,86 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+
+my $CLASS = 'JavaScript::Duktape::XS';
+
+use constant SUCCESSFUL_REQUIRE => <<'EOF';
+var p = require('find_it');
+'require successful';
+EOF
+
+use constant FAILED_REQUIRE => <<'EOF';
+var retval;
+try {
+	require('not_there');
+} catch(e) {
+	retval = 'Perl exception: ' + e.message;
+}
+retval;
+EOF
+
+sub module_resolve {
+	my ($requested_id, $parent_id) = @_;
+
+	my $module_name = sprintf("%s.js", $requested_id);
+	
+	return $module_name;
+}
+
+sub module_load {
+	my ($module_name, $exports, $module) = @_;
+
+	if ('find_it.js' eq $module_name) {
+		return 'module.exports = "found it";';
+	} else {
+		die "module not found\n";
+	}
+}
+
+sub create_duktape {
+	my (%options) = @_;
+
+	my $vm = $CLASS->new({%options});
+	$vm->set(perl_module_resolve => \&module_resolve);
+	$vm->set(perl_module_load => \&module_load);
+
+	return $vm;
+}
+
+sub test_successful_require {
+	my $vm = create_duktape;
+
+	is $vm->eval(SUCCESSFUL_REQUIRE), 'require successful', 'success';
+}
+
+sub test_failed_require {
+	my $vm = create_duktape;
+
+	eval { $vm->eval(FAILED_REQUIRE) };
+	is $@, "Perl sub died with error: module not found\n", 'failed require';
+}
+
+sub test_failed_require_caught {
+	my $vm = create_duktape(catch_resolver_errors => 1);
+
+	my $retval = eval { $vm->eval(FAILED_REQUIRE) };
+	ok !$@, "nothing thrown";
+	is $retval, "Perl exception: module not found\n",
+		'failed require caught';
+}
+
+sub main {
+	use_ok($CLASS);
+
+	test_successful_require;
+	test_failed_require;
+	test_failed_require_caught;
+
+	done_testing;
+
+	return 0;
+}
+
+exit main();


### PR DESCRIPTION
This is my proposed fix for https://github.com/gonzus/JavaScript-Duktape-XS/issues/13.

The new constructor option `catch_perl_expression` converts Perl exceptions to JavaScript `Error` objects and throws them in a catchable manner.

In https://github.com/gonzus/JavaScript-Duktape-XS/issues/13#issuecomment-613877190, you said that the option should be a 3-way option but I didn't really understand what the third option would be.

Feel free to change the option name, I couldn't think of anything better.

Another possibility would be to make the new behaviour the default and do not make it configurable at all. Rationale: If you invoke Perl code from within JavaScript and Perl throws an exception, the JavaScript engine will ultimately terminate with an error and that is the current behaviour. Only when you invoke Perl from within a `try/catch` but when you do this, then you obviously expect Perl exceptions to be catchable. I don't see why anybody would expect or want the old behaviour.