### PR TITLE
Support MSWin32

### DIFF
--- a/c_eventloop.c
+++ b/c_eventloop.c
@@ -3,7 +3,14 @@
  *  heap insertion would be O(log N).
  */
 #include <stdio.h>
+
+#if defined(_WIN32)
+#include <WinSock2.h>
+#define poll WSAPoll
+#pragma comment(lib, "ws2_32")
+#else
 #include <poll.h>
+#endif
 
 #include "duktape.h"
 #include "c_eventloop.h"

--- a/pl_duk.c
+++ b/pl_duk.c
@@ -167,6 +167,8 @@ static SV* pl_duk_to_perl_impl(pTHX_ duk_context* ctx, int pos, HV* seen)
     return ret;
 }
 
+#include <stdio.h>
+
 static int pl_perl_to_duk_impl(pTHX_ SV* value, duk_context* ctx, HV* seen, int ref)
 {
     int ret = 1;
@@ -185,7 +187,7 @@ static int pl_perl_to_duk_impl(pTHX_ SV* value, duk_context* ctx, HV* seen, int 
         const char* vstr = SvPVutf8(value, vlen);
         duk_push_lstring(ctx, vstr, vlen);
     } else if (SvIOK(value)) {
-        long val = SvIV(value);
+        duk_int64_t val = SvIV(value);
         if (ref && (val == 0 || val == 1)) {
             duk_push_boolean(ctx, val);
         } else {


### PR DESCRIPTION
Problems fixed:

* emulate `poll()` was replaced with `WSAPoll()`
* avoid integer overflow because apparently their long ints are only 32 bit

All tests are green on Windows 10 with 64 bit Strawberry Perl 5.32.1.